### PR TITLE
virtual address is different with physical address in some CPU

### DIFF
--- a/common/usbx_host_controllers/src/ux_hcd_ohci_asynchronous_endpoint_destroy.c
+++ b/common/usbx_host_controllers/src/ux_hcd_ohci_asynchronous_endpoint_destroy.c
@@ -169,7 +169,12 @@ ULONG           ohci_register;
     value_td =  (ULONG) _ux_utility_virtual_address(ed -> ux_ohci_ed_head_td) & UX_OHCI_ED_MASK_TD;
     head_td =   (UX_OHCI_TD *) _ux_utility_physical_address((VOID *) value_td);
     ed -> ux_ohci_ed_head_td =  head_td;
-    
+#if 1  // ADDED_BY_LJ  QEPDCLQU <2020.07.24>
+	// because in the line of 'while (head_td != tail_td)', tail_td is a virtual address,
+	// and if it is the first entry the while,head_td->ux_ohci_td_next_td will be an exception,
+	// because virtual addr is not same with physical addr in some CPU, like MIPS , the CPU need a virtual addr not a physical
+	head_td = (UX_OHCI_TD*)value_td;
+#endif
     /* Remove all the tds from this ED and leave the head and tail pointing
        to the dummy TD.  */
     tail_td =  _ux_utility_virtual_address(ed -> ux_ohci_ed_tail_td);

--- a/common/usbx_host_controllers/src/ux_hcd_ohci_next_td_clean.c
+++ b/common/usbx_host_controllers/src/ux_hcd_ohci_next_td_clean.c
@@ -88,7 +88,12 @@ ULONG           value_carry;
     /* Ensure that the potential Halt bit is removed in the head ED.  */
     value_td =  (ULONG) _ux_utility_virtual_address(ed -> ux_ohci_ed_head_td) & UX_OHCI_ED_MASK_TD;
     head_td =   (UX_OHCI_TD *) _ux_utility_physical_address((VOID *) value_td);
-    
+#if 1  // ADDED_BY_LJ  QEPDCLQU <2020.07.24>
+	// because in the line of 'while (head_td != tail_td)', tail_td is a virtual address,
+	// and if it is the first entry the while,head_td->ux_ohci_td_next_td will be an exception,
+	// because virtual addr is not same with physical addr in some CPU, like MIPS , the CPU need a virtual addr not a physical
+	head_td = (UX_OHCI_TD*)value_td;
+#endif
     /* Remove all the tds from this ED and leave the head and tail pointing
        to the dummy TD.  */
     tail_td =  _ux_utility_virtual_address(ed -> ux_ohci_ed_tail_td);

--- a/common/usbx_host_controllers/src/ux_hcd_ohci_periodic_endpoint_destroy.c
+++ b/common/usbx_host_controllers/src/ux_hcd_ohci_periodic_endpoint_destroy.c
@@ -124,7 +124,12 @@ ULONG           value_td;
     value_td =  (ULONG) _ux_utility_virtual_address(ed -> ux_ohci_ed_head_td) & UX_OHCI_ED_MASK_TD;
     head_td =   (UX_OHCI_TD *) _ux_utility_physical_address((VOID *) value_td);
     ed -> ux_ohci_ed_head_td =  head_td;
-    
+#if 1  // ADDED_BY_LJ  QEPDCLQU <2020.07.24>
+	// because in the line of 'while (head_td != tail_td)', tail_td is a virtual address,
+	// and if it is the first entry the while,head_td->ux_ohci_td_next_td will be an exception,
+	// because virtual addr is not same with physical addr in some CPU, like MIPS , the CPU need a virtual addr not a physical
+	head_td = (UX_OHCI_TD*)value_td;
+#endif
     /* Remove all the tds from this ED and leave the head and tail pointing
        to the dummy TD.  */
     tail_td =  _ux_utility_virtual_address(ed -> ux_ohci_ed_tail_td);

--- a/common/usbx_host_controllers/src/ux_hcd_ohci_transfer_abort.c
+++ b/common/usbx_host_controllers/src/ux_hcd_ohci_transfer_abort.c
@@ -114,7 +114,12 @@ ULONG           value_carry;
     value_td =  (ULONG) _ux_utility_virtual_address(ed -> ux_ohci_ed_head_td) & UX_OHCI_ED_MASK_TD;
     head_td =   (UX_OHCI_TD *) _ux_utility_physical_address((VOID *) value_td);
     ed -> ux_ohci_ed_head_td =  head_td;
-    
+#if 1  // ADDED_BY_LJ  QEPDCLQU <2020.07.24>
+	// because in the line of 'while (head_td != tail_td)', tail_td is a virtual address,
+	// and if it is the first entry the while,head_td->ux_ohci_td_next_td will be an exception,
+	// because virtual addr is not same with physical addr in some CPU, like MIPS , the CPU need a virtual addr not a physical
+	head_td = (UX_OHCI_TD*)value_td;  
+#endif
     /* Remove all the tds from this ED and leave the head and tail pointing
        to the dummy TD.  */
     tail_td =  _ux_utility_virtual_address(ed -> ux_ohci_ed_tail_td);


### PR DESCRIPTION
您好，最近我在移植usbx到一个芯片上时，发现usbx上可能存在"bug"。usbx上有两个接口_ux_utility_virtual_address和_ux_utility_physical_address，里面的虚拟地址和物理地址是一一映射的，代码中有很多地方也用到了这两个接口用来实现CPU和HC各自访问所需要的地址空间，但是我发现有些源文件的代码中并没有遵守这样的规则，因为我的芯片上的CPU使用的虚拟地址和物理地址并不是一一映射的，当CPU使用物理地址时，会有异常，而HC使用虚拟地址时也会存在问题(我相信在某些虚拟地址和物理地址不是一一映射的CPU上也会存在同样的问题)。
我的描述是否能说明白我遇到的问题，不知道您那边是否认为这些是"bug"。
所以，我找出了四个文件并进行了修改，如果是“bug”，我相信usbx中并不是只有这4个文件存在这样的问题。
我第一次使用github，所以我将更改的直接提交到了master分支，希望不会造成一些困扰。
以上，谢谢。
p.s. 我希望学习和使用usbx，对于代码中我有很多疑惑，如果可以，我希望能有更方便的交流方式，比如邮件。我的邮箱是：lanxiaoao@163.com