### PR TITLE
Provide a C++ compatible macro definition for UX_NULL

### DIFF
--- a/common/core/inc/ux_api.h
+++ b/common/core/inc/ux_api.h
@@ -1084,7 +1084,11 @@ VOID    _ux_trace_event_update(TX_TRACE_BUFFER_ENTRY *event, ULONG timestamp, UL
 
 /* Define basic USBX constants.  */
 
+#ifdef __cplusplus
+#define UX_NULL                                                         (0)
+#else
 #define UX_NULL                                                         ((void*)0)
+#endif
 #define UX_INVALID_PTR                                                  ((void*)(~((ALIGN_TYPE)0)))
 #define UX_TRUE                                                         1u
 #define UX_FALSE                                                        0u


### PR DESCRIPTION
We have a macro stands for null pointers. i.e. `UX_NULL`. Currently its definition is
```c
#define UX_NULL                                                         ((void*)0)
```
It works perfectly for C projects. But when it comes to C++, we will get compilation errors because `((void*)0)` is not allowed in C++ as a null pointer [1]. Instead, `0` or `nullptr` are allowed. So we need to change the macro definition in C++.

In the PR I use the presence of macro `__cplusplus` to distinguish C and C++ environments. We will still get the original definitions when we compile C sources.

[1] https://en.cppreference.com/w/cpp/types/NULL